### PR TITLE
Fixed float regex to accept formats like 1E5, 1E-5 and 1E

### DIFF
--- a/lib/CrEOF/Geo/String/Lexer.php
+++ b/lib/CrEOF/Geo/String/Lexer.php
@@ -107,7 +107,7 @@ class Lexer extends AbstractLexer
     {
         return array(
             '[nesw\'",\X]',
-            '(?:[0-9]+)(?:[\.][0-9]+)?'
+            '(?:[0-9]+)(?:[\.][0-9]+)?(?:e[+-]?[0-9]+)?'
         );
     }
 


### PR DESCRIPTION
Because `echo 0.00001` prints `1.0E-5` so polygons with small numbers fail.
